### PR TITLE
feat: :fire: remove `google_fonts` dependencies (+ fixes)

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,12 +2,7 @@ import 'dart:ui';
 import 'package:any_syntax_highlighter/any_syntax_highlighter.dart';
 import 'package:any_syntax_highlighter/themes/any_syntax_highlighter_theme.dart';
 import 'package:any_syntax_highlighter/themes/any_syntax_highlighter_theme_collection.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/painting.dart';
-import 'package:flutter/rendering.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 
 const fontStyles = <String, FontStyle>{
@@ -53,7 +48,7 @@ class MainApp extends StatefulWidget {
   const MainApp({Key? key}) : super(key: key);
 
   @override
-  _MainApp createState() => _MainApp();
+  State<MainApp> createState() => _MainApp();
 }
 
 class _MainApp extends State<MainApp> {
@@ -75,7 +70,6 @@ class _MainApp extends State<MainApp> {
           lineNumbers: Props.lineNumbers,
           isSelectableText: Props.isSelectableText,
           hasCopyButton: Props.hasCopyButton,
-          useGoogleFont: Props.useGoogleFont,
           theme: AnySyntaxHighlighterTheme(
             lineNumber: TextStyle(
                 color: _theme['lineNumber']?.color,
@@ -198,7 +192,6 @@ class _MainApp extends State<MainApp> {
                                 color: Colors.black),
                             theme: AnySyntaxHighlighterThemeCollection
                                 .freeLineTheme(),
-                            useGoogleFont: 'Comfortaa',
                             overrideDecoration: BoxDecoration(
                                 color: (AnySyntaxHighlighterThemeCollection
                                             .freeLineTheme()
@@ -286,8 +279,7 @@ class _MainApp extends State<MainApp> {
                     ],
                   ))
               .toList()
-            ..add(Wrap(
-                children: [
+            ..add(Wrap(children: [
               const Text('background color'),
               TextButton(
                 child: Text('change..',
@@ -439,26 +431,27 @@ class _MainApp extends State<MainApp> {
                   }),
               const Text("Show Line Numbers"),
               const Text('Choose Font Features'),
-            ]..addAll(fontFeatures.keys
-                    .map((k) => Row(
-                          children: [
-                            Checkbox(
-                                value: Props.fontFeatures.contains(k),
-                                onChanged: (b) {
-                                  if (b == true) {
-                                    setState(() {
-                                      Props.fontFeatures.add(k);
-                                    });
-                                  } else {
-                                    setState(() {
-                                      Props.fontFeatures.remove(k);
-                                    });
-                                  }
-                                }),
-                            Text(k)
-                          ],
-                        ))
-                    .toList()))),
+              ...fontFeatures.keys
+                  .map((final String key) => Row(
+                        children: [
+                          Checkbox(
+                              value: Props.fontFeatures.contains(key),
+                              onChanged: (b) {
+                                if (b == true) {
+                                  setState(() {
+                                    Props.fontFeatures.add(key);
+                                  });
+                                } else {
+                                  setState(() {
+                                    Props.fontFeatures.remove(key);
+                                  });
+                                }
+                              }),
+                          Text(key)
+                        ],
+                      ))
+                  .toList(),
+            ])),
         ),
       )),
     );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,15 +7,15 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.12"
+    version: "0.0.13"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,10 +28,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -44,10 +44,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   crypto:
     dependency: transitive
     description:
@@ -138,14 +138,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.5"
   lints:
     dependency: transitive
     description:
@@ -158,34 +150,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   path_provider:
     dependency: transitive
     description:
@@ -267,26 +259,26 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -307,10 +299,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.6.1"
   typed_data:
     dependency: transitive
     description:
@@ -327,6 +319,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   win32:
     dependency: transitive
     description:
@@ -344,5 +344,5 @@ packages:
     source: hosted
     version: "1.0.0"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -62,8 +62,7 @@ flutter:
   uses-material-design: true
 
   # To add assets to your application, add an assets section, like this:
-  assets:
-    - google_fonts/
+  # assets:
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
 

--- a/lib/any_syntax_highlighter.dart
+++ b/lib/any_syntax_highlighter.dart
@@ -11,7 +11,6 @@ import 'package:any_syntax_highlighter/utils/token.dart';
 import 'package:any_syntax_highlighter/utils/token_types.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:google_fonts/google_fonts.dart';
 
 /// widget AnySyntaxHighlighter this widget will provide the syntax highlighting to input text
 class AnySyntaxHighlighter extends StatelessWidget {
@@ -64,12 +63,6 @@ class AnySyntaxHighlighter extends StatelessWidget {
   /// if true an additional line numbers widget will appear in left hand side
   final bool lineNumbers;
 
-  /// choose google fonts you wish to use
-  /// if it's value is null no google fonts will be used
-  /// if not null it will use GoogleFonts.getFont(useGoogleFont) to get
-  /// that font
-  final String? useGoogleFont;
-
   /// set of reserved words for this instance of AnySyntaxHighlighter
   /// this allows to create language specific highlighting
   /// user can add desired reserved words for a language by using
@@ -104,7 +97,6 @@ class AnySyntaxHighlighter extends StatelessWidget {
       this.isSelectableText = false,
       this.theme = const AnySyntaxHighlighterTheme(),
       this.fontSize,
-      this.useGoogleFont,
       this.reservedWordSets = const {
         'java',
         'python',
@@ -406,23 +398,17 @@ class AnySyntaxHighlighter extends StatelessWidget {
             ? SelectableText.rich(
                 TextSpan(
                   text: '',
-                  style: useGoogleFont == null
-                      ? TextStyle(
-                          fontSize: fontSize,
-                          fontFamily: theme.fontFamily,
-                          letterSpacing: theme.letterSpacing,
-                          wordSpacing: theme.wordSpacing,
-                          fontFeatures: theme.fontFeatures)
-                      : GoogleFonts.getFont(useGoogleFont!,
-                          fontSize: fontSize,
-                          letterSpacing: theme.letterSpacing,
-                          wordSpacing: theme.wordSpacing,
-                          fontFeatures: theme.fontFeatures),
+                  style: TextStyle(
+                      fontSize: fontSize,
+                      fontFamily: theme.fontFamily,
+                      letterSpacing: theme.letterSpacing,
+                      wordSpacing: theme.wordSpacing,
+                      fontFeatures: theme.fontFeatures),
                   children: _createSpans(),
                 ),
                 textAlign: textAlign,
                 textDirection: textDirection,
-                textScaleFactor: textScaleFactor,
+                textScaler: TextScaler.linear(textScaleFactor),
                 maxLines: maxLines,
                 strutStyle: strutStyle,
                 textWidthBasis: textWidthBasis,
@@ -431,25 +417,19 @@ class AnySyntaxHighlighter extends StatelessWidget {
             : RichText(
                 text: TextSpan(
                   text: '',
-                  style: useGoogleFont == null
-                      ? TextStyle(
-                          fontSize: fontSize,
-                          fontFamily: theme.fontFamily,
-                          letterSpacing: theme.letterSpacing,
-                          wordSpacing: theme.wordSpacing,
-                          fontFeatures: theme.fontFeatures)
-                      : GoogleFonts.getFont(useGoogleFont!,
-                          fontSize: fontSize,
-                          letterSpacing: theme.letterSpacing,
-                          wordSpacing: theme.wordSpacing,
-                          fontFeatures: theme.fontFeatures),
+                  style: TextStyle(
+                      fontSize: fontSize,
+                      fontFamily: theme.fontFamily,
+                      letterSpacing: theme.letterSpacing,
+                      wordSpacing: theme.wordSpacing,
+                      fontFeatures: theme.fontFeatures),
                   children: _createSpans(),
                 ),
                 textAlign: textAlign,
                 textDirection: textDirection,
                 softWrap: softWrap,
                 overflow: overflow,
-                textScaleFactor: textScaleFactor,
+                textScaler: TextScaler.linear(textScaleFactor),
                 maxLines: maxLines,
                 locale: locale,
                 strutStyle: strutStyle,
@@ -488,13 +468,9 @@ class AnySyntaxHighlighter extends StatelessWidget {
             text: TextSpan(
                 text: '',
                 children: lineNumberWidgets,
-                style: useGoogleFont == null
-                    ? TextStyle(
+                style: TextStyle(
                         fontSize: fontSize,
-                      )
-                    : GoogleFonts.getFont(useGoogleFont!,
-                        fontSize: fontSize,
-                        backgroundColor: Colors.transparent)),
+                      ),
           ),
         ]),
         Expanded(child: _highlighter())

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -37,18 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
-  crypto:
-    dependency: transitive
-    description:
-      name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.2"
+    version: "1.18.0"
   fake_async:
     dependency: transitive
     description:
@@ -57,22 +49,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
-  ffi:
-    dependency: transitive
-    description:
-      name: ffi
-      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
-  file:
-    dependency: transitive
-    description:
-      name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -91,38 +67,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  google_fonts:
-    dependency: "direct main"
-    description:
-      name: google_fonts
-      sha256: "927573f2e8a8d65c17931e21918ad0ab0666b1b636537de7c4932bdb487b190f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.3"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.13.5"
-  http_parser:
-    dependency: transitive
-    description:
-      name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.5"
   lints:
     dependency: transitive
     description:
@@ -135,106 +79,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
-  path_provider:
-    dependency: transitive
-    description:
-      name: path_provider
-      sha256: c7edf82217d4b2952b2129a61d3ad60f1075b9299e629e149a8d2e39c2e6aad4
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.14"
-  path_provider_android:
-    dependency: transitive
-    description:
-      name: path_provider_android
-      sha256: "019f18c9c10ae370b08dce1f3e3b73bc9f58e7f087bb5e921f06529438ac0ae7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.24"
-  path_provider_foundation:
-    dependency: transitive
-    description:
-      name: path_provider_foundation
-      sha256: "12eee51abdf4d34c590f043f45073adbb45514a108bd9db4491547a2fd891059"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.0"
-  path_provider_linux:
-    dependency: transitive
-    description:
-      name: path_provider_linux
-      sha256: "2ae08f2216225427e64ad224a24354221c2c7907e448e6e0e8b57b1eb9f10ad1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.10"
-  path_provider_platform_interface:
-    dependency: transitive
-    description:
-      name: path_provider_platform_interface
-      sha256: "57585299a729335f1298b43245842678cb9f43a6310351b18fb577d6e33165ec"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.6"
-  path_provider_windows:
-    dependency: transitive
-    description:
-      name: path_provider_windows
-      sha256: f53720498d5a543f9607db4b0e997c4b5438884de25b0f73098cc2671a51b130
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.5"
-  platform:
-    dependency: transitive
-    description:
-      name: platform
-      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.0"
-  plugin_platform_interface:
-    dependency: transitive
-    description:
-      name: plugin_platform_interface
-      sha256: "6a2128648c854906c53fa8e33986fc0247a1116122f9534dd20e3ab9e16a32bc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.4"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.2.4"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -244,26 +116,26 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -284,18 +156,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.1"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
@@ -304,22 +168,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  win32:
+  web:
     dependency: transitive
     description:
-      name: win32
-      sha256: c9ebe7ee4ab0c2194e65d3a07d8c54c5d00bb001b76081c4a04cdb8448b59e46
+      name: web
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
-  xdg_directories:
-    dependency: transitive
-    description:
-      name: xdg_directories
-      sha256: ee1505df1426458f7f60aac270645098d318a8b4766d85fde75f76f2e21807d1
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
+    version: "0.3.0"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
+  flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_fonts: ^4.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Hi,
Thank you for this nice package.
I recently noticed a version conflict in my project while using the last version of `google_fonts` (current at 6.1.0 as of speaking). This is because `any_syntax_highlighter` (`0.0.13`) use its own version of `google_fonts` (`4.0.3`).

I would like to suggest a solution:

## Solution
The package should let the user use any external font. I don't think that depending on `google_fonts` is useful here since we can pass any `TextStyle` variable, including one coming from `google_fonts`.

So I made these changes:
* Remove `google_fonts` dependency package from `pubspec.yaml`
* Remove `useGoogleFont` property (parameter) from `AnySyntaxHighlighter ` class

I also took the freedom to:

* Migrate deprecated API (e.g. `textScaleFactor`)
* Remove unused imports (e.g. in `example/lib/main.dart`)

Let me know what you think.
Have a nice day.
